### PR TITLE
Java 8 compatibility

### DIFF
--- a/scripts/java/build.sh
+++ b/scripts/java/build.sh
@@ -4,7 +4,7 @@ set -e
 
 DIR=$(dirname $0)
 
-javac -d $DIR/bin init.java
+javac -d $DIR/bin -source 8 -target 8 init.java
 cd $DIR/bin
 jar cvfm $DIR/../../init.jar ../Manifest.txt .
 cd $DIR

--- a/scripts/java/init.java
+++ b/scripts/java/init.java
@@ -1,92 +1,143 @@
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class init {
-  public static void main(String[] args) throws Exception {
-    System.out.println("Installing client...");
-    File clientFile =
-        File.createTempFile("tunshell-client", "", new File(System.getProperty("java.io.tmpdir")));
 
-    String url = String.format("https://artifacts.tunshell.com/client-%s", getTarget());
-    try (InputStream in = new URL(url).openStream()) {
-      Files.copy(in, Paths.get(clientFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
+  public enum Os {
+    LINUX,
+    OSX,
+    WINDOWS;
+
+    public static Os detect() {
+      return from(System.getProperty("os.name").toLowerCase());
     }
 
-    clientFile.setExecutable(true);
-
-    List<String> command =
-        new ArrayList<String>() {
-          {
-            add(clientFile.getAbsolutePath());
-            addAll(Arrays.asList(args));
-          }
-        };
-    ProcessBuilder pb = new ProcessBuilder(command);
-    pb.inheritIO();
-    Process process = pb.start();
-    process.waitFor();
+    public static Os from(String name) {
+      switch (name) {
+        case "linux":
+          return Os.LINUX;
+        case "os x":
+        case "mac":
+        case "mac os x":
+          return Os.OSX;
+        case "windows":
+          return Os.WINDOWS;
+      }
+      throw new RuntimeException(String.format("Unsupported platform: %s", name));
+    }
   }
 
-  private static String getTarget() throws Exception {
-    Map<String, Map<String, String>> targets =
-        new HashMap<String, Map<String, String>>() {
-          {
-            put(
-                "linux",
-                new HashMap<String, String>() {
-                  {
-                    put("x86_64", "x86_64-unknown-linux-musl");
-                    put("i686", "i686-unknown-linux-musl");
-                    put("arm", "armv7-unknown-linux-musleabihf");
-                    put("arm64", "aarch64-unknown-linux-musl");
-                  }
-                });
-            put(
-                "osx",
-                new HashMap<String, String>() {
-                  {
-                    put("x86_64", "x86_64-apple-darwin");
-                  }
-                });
-            put(
-                "windows",
-                new HashMap<String, String>() {
-                  {
-                    put("x86_64", "x86_64-pc-windows-msvc.exe");
-                    put("i686", "i686-pc-windows-msvc.exe");
-                  }
-                });
-          }
-        };
+  public enum Arch {
+    X86_64,
+    I686,
+    ARM,
+    ARM64;
 
-    String os = System.getProperty("os.name").toLowerCase();
-    Map<String, String> osTargets = null;
-
-    if (os.contains("linux")) {
-      osTargets = targets.get("linux");
-    } else if (os.contains("mac") || os.contains("os x")) {
-      osTargets = targets.get("osx");
-    } else if (os.contains("windows")) {
-      osTargets = targets.get("windows");
-    } else {
-      throw new Exception(String.format("Unsupported platform: %s", os));
+    public static Arch detect() {
+      return from(System.getProperty("os.arch").toLowerCase());
     }
 
-    String cpu = System.getProperty("os.arch");
+    public static Arch from(String name) {
+      switch (name) {
+        case "x86_64":
+          return Arch.X86_64;
+        case "i686":
+          return Arch.I686;
+        case "arm":
+          return Arch.ARM;
+        case "arm64":
+          return Arch.ARM64;
+      }
+      throw new RuntimeException(String.format("Unsupported CPU architecture: %s", name));
+    }
+  }
 
-    if (!osTargets.containsKey(cpu)) {
-      throw new Exception(String.format("Unsupported CPU architecture: %s", cpu));
+  public static class OsArch {
+    private final Os os;
+    private final Arch arch;
+
+    public OsArch(Os os, Arch arch) {
+      this.os = Objects.requireNonNull(os);
+      this.arch = Objects.requireNonNull(arch);
     }
 
-    return osTargets.get(cpu);
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      OsArch osArch = (OsArch) o;
+      if (os != osArch.os) {
+        return false;
+      }
+      return arch == osArch.arch;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = os.hashCode();
+      result = 31 * result + arch.hashCode();
+      return result;
+    }
+  }
+
+  private static final Map<OsArch, String> SUPPORTED_TARGETS;
+
+  static {
+    final Map<OsArch, String> targets = new HashMap<>();
+    targets.put(new OsArch(Os.LINUX, Arch.X86_64), "x86_64-unknown-linux-musl");
+    targets.put(new OsArch(Os.LINUX, Arch.I686), "i686-unknown-linux-musl");
+    targets.put(new OsArch(Os.LINUX, Arch.ARM), "armv7-unknown-linux-musleabihf");
+    targets.put(new OsArch(Os.LINUX, Arch.ARM64), "aarch64-unknown-linux-musl");
+    targets.put(new OsArch(Os.OSX, Arch.X86_64), "x86_64-apple-darwin");
+    targets.put(new OsArch(Os.WINDOWS, Arch.X86_64), "x86_64-pc-windows-msvc.exe");
+    targets.put(new OsArch(Os.WINDOWS, Arch.I686), "i686-pc-windows-msvc.exe");
+    SUPPORTED_TARGETS = Collections.unmodifiableMap(targets);
+  }
+
+  public static String getTarget(Os os, Arch arch) {
+    final String target = SUPPORTED_TARGETS.get(new OsArch(os, arch));
+    if (target == null) {
+      throw new RuntimeException(
+        String.format("Unsupported platform / CPU architecture: %s / %s", os, arch));
+    }
+    return target;
+  }
+
+  public static String getTarget() {
+    return getTarget(Os.detect(), Arch.detect());
+  }
+
+  public static void main(String[] args) throws IOException, InterruptedException {
+    System.out.println("Installing client...");
+
+    final File clientFile = File.createTempFile("tunshell-client", null);
+    final String url = String.format("https://artifacts.tunshell.com/client-%s", getTarget());
+    try (final InputStream in = new URL(url).openStream()) {
+      Files.copy(in, clientFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    }
+    if (!clientFile.setExecutable(true)) {
+      throw new RuntimeException(String.format("Unable to mark '%s' as executable", clientFile));
+    }
+
+    new ProcessBuilder(
+      Stream.concat(Stream.of(clientFile.getAbsolutePath()), Stream.of(args))
+        .collect(Collectors.toList()))
+      .inheritIO()
+      .start()
+      .waitFor();
   }
 }

--- a/scripts/java/init.java
+++ b/scripts/java/init.java
@@ -1,4 +1,5 @@
 import java.io.File;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -6,34 +7,36 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class init {
     public static void main(String[] args) throws Exception {
         System.out.println("Installing client...");
-        var clientFile = File.createTempFile("tunshell-client", "",
+        File clientFile = File.createTempFile("tunshell-client", "",
                 new File(System.getProperty("java.io.tmpdir")));
 
-        var url = String.format("https://artifacts.tunshell.com/client-%s", getTarget());
-        try (var in = new URL(url).openStream()) {
+        String url = String.format("https://artifacts.tunshell.com/client-%s", getTarget());
+        try (InputStream in = new URL(url).openStream()) {
             Files.copy(in, Paths.get(clientFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
         }
 
         clientFile.setExecutable(true);
 
-        var command = new ArrayList<String>() {
+        List<String> command = new ArrayList<String>() {
             {
                 add(clientFile.getAbsolutePath());
                 addAll(Arrays.asList(args));
             }
         };
-        var pb = new ProcessBuilder(command);
+        ProcessBuilder pb = new ProcessBuilder(command);
         pb.inheritIO();
-        var process = pb.start();
+        Process process = pb.start();
         process.waitFor();
     }
 
     private static String getTarget() throws Exception {
-        var targets = new HashMap<String, HashMap<String, String>>() {
+        Map<String, Map<String, String>> targets = new HashMap<String, Map<String, String>>() {
             {
                 put("linux", new HashMap<String, String>() {
                     {
@@ -57,8 +60,8 @@ public class init {
             }
         };
 
-        var os = System.getProperty("os.name").toLowerCase();
-        HashMap<String, String> osTargets = null;
+        String os = System.getProperty("os.name").toLowerCase();
+        Map<String, String> osTargets = null;
 
         if (os.contains("linux")) {
             osTargets = targets.get("linux");
@@ -70,7 +73,7 @@ public class init {
             throw new Exception(String.format("Unsupported platform: %s", os));
         }
 
-        var cpu = System.getProperty("os.arch");
+        String cpu = System.getProperty("os.arch");
 
         if (!osTargets.containsKey(cpu)) {
             throw new Exception(String.format("Unsupported CPU architecture: %s", cpu));

--- a/scripts/java/init.java
+++ b/scripts/java/init.java
@@ -11,74 +11,82 @@ import java.util.List;
 import java.util.Map;
 
 public class init {
-    public static void main(String[] args) throws Exception {
-        System.out.println("Installing client...");
-        File clientFile = File.createTempFile("tunshell-client", "",
-                new File(System.getProperty("java.io.tmpdir")));
+  public static void main(String[] args) throws Exception {
+    System.out.println("Installing client...");
+    File clientFile =
+        File.createTempFile("tunshell-client", "", new File(System.getProperty("java.io.tmpdir")));
 
-        String url = String.format("https://artifacts.tunshell.com/client-%s", getTarget());
-        try (InputStream in = new URL(url).openStream()) {
-            Files.copy(in, Paths.get(clientFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
-        }
-
-        clientFile.setExecutable(true);
-
-        List<String> command = new ArrayList<String>() {
-            {
-                add(clientFile.getAbsolutePath());
-                addAll(Arrays.asList(args));
-            }
-        };
-        ProcessBuilder pb = new ProcessBuilder(command);
-        pb.inheritIO();
-        Process process = pb.start();
-        process.waitFor();
+    String url = String.format("https://artifacts.tunshell.com/client-%s", getTarget());
+    try (InputStream in = new URL(url).openStream()) {
+      Files.copy(in, Paths.get(clientFile.getPath()), StandardCopyOption.REPLACE_EXISTING);
     }
 
-    private static String getTarget() throws Exception {
-        Map<String, Map<String, String>> targets = new HashMap<String, Map<String, String>>() {
-            {
-                put("linux", new HashMap<String, String>() {
-                    {
-                        put("x86_64", "x86_64-unknown-linux-musl");
-                        put("i686", "i686-unknown-linux-musl");
-                        put("arm", "armv7-unknown-linux-musleabihf");
-                        put("arm64", "aarch64-unknown-linux-musl");
-                    }
+    clientFile.setExecutable(true);
+
+    List<String> command =
+        new ArrayList<String>() {
+          {
+            add(clientFile.getAbsolutePath());
+            addAll(Arrays.asList(args));
+          }
+        };
+    ProcessBuilder pb = new ProcessBuilder(command);
+    pb.inheritIO();
+    Process process = pb.start();
+    process.waitFor();
+  }
+
+  private static String getTarget() throws Exception {
+    Map<String, Map<String, String>> targets =
+        new HashMap<String, Map<String, String>>() {
+          {
+            put(
+                "linux",
+                new HashMap<String, String>() {
+                  {
+                    put("x86_64", "x86_64-unknown-linux-musl");
+                    put("i686", "i686-unknown-linux-musl");
+                    put("arm", "armv7-unknown-linux-musleabihf");
+                    put("arm64", "aarch64-unknown-linux-musl");
+                  }
                 });
-                put("osx", new HashMap<String, String>() {
-                    {
-                        put("x86_64", "x86_64-apple-darwin");
-                    }
+            put(
+                "osx",
+                new HashMap<String, String>() {
+                  {
+                    put("x86_64", "x86_64-apple-darwin");
+                  }
                 });
-                put("windows", new HashMap<String, String>() {
-                    {
-                        put("x86_64", "x86_64-pc-windows-msvc.exe");
-                        put("i686", "i686-pc-windows-msvc.exe");
-                    }
+            put(
+                "windows",
+                new HashMap<String, String>() {
+                  {
+                    put("x86_64", "x86_64-pc-windows-msvc.exe");
+                    put("i686", "i686-pc-windows-msvc.exe");
+                  }
                 });
-            }
+          }
         };
 
-        String os = System.getProperty("os.name").toLowerCase();
-        Map<String, String> osTargets = null;
+    String os = System.getProperty("os.name").toLowerCase();
+    Map<String, String> osTargets = null;
 
-        if (os.contains("linux")) {
-            osTargets = targets.get("linux");
-        } else if (os.contains("mac") || os.contains("os x")) {
-            osTargets = targets.get("osx");
-        } else if (os.contains("windows")) {
-            osTargets = targets.get("windows");
-        } else {
-            throw new Exception(String.format("Unsupported platform: %s", os));
-        }
-
-        String cpu = System.getProperty("os.arch");
-
-        if (!osTargets.containsKey(cpu)) {
-            throw new Exception(String.format("Unsupported CPU architecture: %s", cpu));
-        }
-
-        return osTargets.get(cpu);
+    if (os.contains("linux")) {
+      osTargets = targets.get("linux");
+    } else if (os.contains("mac") || os.contains("os x")) {
+      osTargets = targets.get("osx");
+    } else if (os.contains("windows")) {
+      osTargets = targets.get("windows");
+    } else {
+      throw new Exception(String.format("Unsupported platform: %s", os));
     }
+
+    String cpu = System.getProperty("os.arch");
+
+    if (!osTargets.containsKey(cpu)) {
+      throw new Exception(String.format("Unsupported CPU architecture: %s", cpu));
+    }
+
+    return osTargets.get(cpu);
+  }
 }


### PR DESCRIPTION
This PR makes the jar compatible with java 8 by restricting the language feature set to java 8, and compiling with the appropriate target. It should still be compatible with java 9+ JVMs.

This commit is broken up into 2 main parts. The first commit is a bare-bones changeset that is the real change I'm looking for. Edit: as such, I suggest starting the review by looking at just the first commit.

The second and third commits are opinionated refactorings. As such, I'd be happy to sideline these changes and retarget just the first commit if you feel it's more appropriate.

I've tested this on OS X with java 8, and it works. I'm happy to help test this in other environments if desired.

Cheers!

Note: I think there are some cool things you may be able to do in the future if desired - the static binaries could be packaged into the the jar(s) so that the client only needs to do a single download.