### PR TITLE
Client - Fallback to Websocket 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,6 +2088,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "async-tungstenite",
  "byteorder",
  "cfg-if",
  "console_error_panic_hook",

--- a/tunshell-client/Cargo.toml
+++ b/tunshell-client/Cargo.toml
@@ -34,6 +34,7 @@ webpki-roots = "0.19.0"
 crossterm = { version = "0.17.5" }
 libc = "0.2.71"
 ring = "0.16.15"
+async-tungstenite = { version = "0.8.0", features=["tokio-runtime"] } #no-wasm
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "0.2.21", features=["blocking", "time", "io-util", "sync", "macros"] }

--- a/tunshell-client/src/client.rs
+++ b/tunshell-client/src/client.rs
@@ -359,6 +359,7 @@ mod tests {
             "invalid_key",
             "relay.tunshell.com",
             5000,
+            443,
             "test",
             true,
         );

--- a/tunshell-client/src/server/dual_stream.rs
+++ b/tunshell-client/src/server/dual_stream.rs
@@ -1,0 +1,75 @@
+use super::tls_stream::TlsServerStream;
+use super::websocket_stream::WebsocketServerStream;
+use crate::Config;
+use anyhow::Result;
+use log::*;
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    time::timeout,
+};
+
+pub struct ServerStream {
+    inner: Box<dyn super::AsyncIO>,
+}
+
+impl ServerStream {
+    pub async fn connect(config: &Config) -> Result<Self> {
+        let connection = timeout(
+            config.server_connection_timeout(),
+            TlsServerStream::connect(config, config.relay_tls_port()),
+        )
+        .await;
+
+        let connection: Box<dyn super::AsyncIO> = match connection {
+            Ok(Ok(con)) => Box::new(con),
+            _ => {
+                error!("Failed to connect via TLS, falling back to websocket");
+                let ws = timeout(
+                    config.server_connection_timeout(),
+                    WebsocketServerStream::connect(config),
+                )
+                .await??;
+
+                Box::new(ws)
+            }
+        };
+
+        Ok(Self { inner: connection })
+    }
+}
+
+impl AsyncRead for ServerStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for ServerStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, io::Error>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}

--- a/tunshell-client/src/server/mod.rs
+++ b/tunshell-client/src/server/mod.rs
@@ -1,10 +1,16 @@
 cfg_if::cfg_if! {
     if #[cfg(not(target_arch = "wasm32"))] {
-        mod tls_server_stream;
-        pub use tls_server_stream::*;
+        use tokio::io::{AsyncRead, AsyncWrite};
+        
+        pub trait AsyncIO : AsyncRead + AsyncWrite + Send + Unpin {}
+
+        pub mod tls_stream;
+        pub mod websocket_stream;
+        mod dual_stream;
+        pub use dual_stream::*;
     } else {
-        mod websocket_stream;
-        pub use websocket_stream::*;
+        mod websys_websocket_stream;
+        pub use websys_websocket_stream::*;
     }
 }
 
@@ -21,6 +27,7 @@ mod tests {
             "test",
             "relay.tunshell.com",
             5000,
+            443,
             "test",
             true,
         );

--- a/tunshell-client/src/server/tls_stream.rs
+++ b/tunshell-client/src/server/tls_stream.rs
@@ -15,12 +15,12 @@ use tokio::{
 use tokio_rustls::{client::TlsStream, rustls::ClientConfig, TlsConnector};
 use webpki::DNSNameRef;
 
-pub struct ServerStream {
+pub struct TlsServerStream {
     inner: TlsStream<TcpStream>,
 }
 
-impl ServerStream {
-    pub async fn connect(config: &Config) -> Result<Self> {
+impl TlsServerStream {
+    pub async fn connect(config: &Config, port: u16) -> Result<Self> {
         let mut tls_config = ClientConfig::default();
         tls_config
             .root_store
@@ -53,7 +53,7 @@ impl ServerStream {
 
         let relay_dns_name = DNSNameRef::try_from_ascii_str(config.relay_host())?;
 
-        let relay_addr = (config.relay_host(), config.relay_port())
+        let relay_addr = (config.relay_host(), port)
             .to_socket_addrs()?
             .next()
             .unwrap();
@@ -68,7 +68,7 @@ impl ServerStream {
     }
 }
 
-impl AsyncRead for ServerStream {
+impl AsyncRead for TlsServerStream {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -78,7 +78,7 @@ impl AsyncRead for ServerStream {
     }
 }
 
-impl AsyncWrite for ServerStream {
+impl AsyncWrite for TlsServerStream {
     fn poll_write(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -98,3 +98,5 @@ impl AsyncWrite for ServerStream {
         Pin::new(&mut self.inner).poll_shutdown(cx)
     }
 }
+
+impl super::AsyncIO for TlsServerStream {}

--- a/tunshell-client/src/server/websocket_stream.rs
+++ b/tunshell-client/src/server/websocket_stream.rs
@@ -1,293 +1,142 @@
+use super::tls_stream::TlsServerStream;
 use crate::Config;
 use anyhow::Result;
+use async_tungstenite::{client_async, tungstenite::Message, WebSocketStream};
+use futures::{stream::StreamExt, SinkExt};
+use log::*;
 use std::{
-    cmp,
-    io,
+    cmp, io,
     pin::Pin,
-    task::{Context, Poll, Waker},
-    sync::{Arc, Mutex}
+    task::{Context, Poll},
 };
 use tokio::io::{AsyncRead, AsyncWrite};
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::spawn_local;
-use web_sys::{ErrorEvent, MessageEvent, WebSocket};
-use log::*;
-use futures::future::poll_fn;
+use tokio_util::compat::*;
 
-pub struct ServerStream {
-    state: Arc<Mutex<State>>
+pub struct WebsocketServerStream {
+    inner: WebSocketStream<Compat<TlsServerStream>>,
+
+    read_buff: Vec<u8>,
+    write_buff: Option<Message>,
 }
 
-struct State {
-    con_state: ConnectionState,
-
-    recv_buff: Vec<u8>,
-    recv_wakers: Vec<Waker>,
-
-    send_buff: Vec<u8>,
-    send_wakers: Vec<Waker>,
-
-    close_wakers: Vec<Waker>,
-}
-
-impl State {
-    fn new() -> Self {
-        Self {
-            con_state: ConnectionState::Connecting,
-            recv_buff: vec![],
-            recv_wakers: vec![],
-            send_buff: vec![],
-            send_wakers: vec![],
-            close_wakers: vec![],
-        }
-    }
-
-    fn wake_recv(&mut self) {
-        for waker in self.recv_wakers.drain(..) {
-            waker.wake();
-        }
-    }
-
-    fn wake_send(&mut self) {
-        for waker in self.send_wakers.drain(..) {
-            waker.wake();
-        }
-    }
-
-    fn wake_close(&mut self) {
-        for waker in self.close_wakers.drain(..) {
-            waker.wake();
-        }
-    }
-}
-
-#[derive(PartialEq, Copy, Clone, Debug)]
-enum ConnectionState {
-    Connecting,
-    Open,
-    Closing,
-    Closed
-}
-
-impl ServerStream {
+impl WebsocketServerStream {
     pub async fn connect(config: &Config) -> Result<Self> {
-        let state = State::new();
-        let state = Arc::new(Mutex::new(state));
+        let tls_stream = TlsServerStream::connect(config, config.relay_ws_port()).await?;
 
-        let url = format!("wss://{}:{}/ws", config.relay_host(), config.relay_port());
-        let ws = WebSocket::new(&url).unwrap();
-
-        ws.set_binary_type(web_sys::BinaryType::Arraybuffer);
-        
-        // Recv
-        {
-            let state = Arc::clone(&state);
-
-            let callback = Closure::wrap(Box::new(move |e: MessageEvent| {
-                if let Ok(abuf) = e.data().dyn_into::<js_sys::ArrayBuffer>() {
-                    let array = js_sys::Uint8Array::new(&abuf);
-                    let len = array.byte_length() as usize;
-                    debug!("message event, received arraybuffer of {} bytes", len);
-                    
-                    let mut state = state.lock().unwrap();
-
-                    state.recv_buff.extend_from_slice(&array.to_vec()[..]);
-                    state.wake_recv();
-                } else if let Ok(blob) = e.data().dyn_into::<web_sys::Blob>() {
-                    warn!("message event, received blob: {:?}", blob);
-                } else if let Ok(txt) = e.data().dyn_into::<js_sys::JsString>() {
-                    warn!("message event, received Text: {:?}", txt);
-                } else {
-                    warn!("message event, received Unknown: {:?}", e.data());
-                }
-            }) as Box<dyn FnMut(MessageEvent)>);
-
-            ws.set_onmessage(Some(callback.as_ref().unchecked_ref()));
-            callback.forget();
-        }
-
-        // Error
-        {
-            let callback = Closure::wrap(Box::new(move |e: ErrorEvent| {
-                error!("error event: {:?}", e);
-            }) as Box<dyn FnMut(ErrorEvent)>);
-            ws.set_onerror(Some(callback.as_ref().unchecked_ref()));
-            callback.forget();
-        }
-
-        // Closed
-        {
-            let state = Arc::clone(&state);
-            let callback = Closure::wrap(Box::new(move |_e: ErrorEvent| {
-                let mut state = state.lock().unwrap();
-                state.con_state = ConnectionState::Closed;
-                state.wake_close();
-                state.wake_recv();
-                state.wake_send();
-                debug!("socket closed");
-            }) as Box<dyn FnMut(ErrorEvent)>);
-            ws.set_onclose(Some(callback.as_ref().unchecked_ref()));
-            callback.forget();
-        }
-
-        // Open 
-        {
-            let state = Arc::clone(&state);
-            let callback = Closure::wrap(Box::new(move |_| {
-                let mut state = state.lock().unwrap();
-                state.con_state = ConnectionState::Open;
-                state.wake_send();
-                debug!("socket opened");
-            }) as Box<dyn FnMut(JsValue)>);
-            ws.set_onopen(Some(callback.as_ref().unchecked_ref()));
-            callback.forget();
-        }
-
-        // Write loop
-        {
-            let state = Arc::clone(&state);
-            let ws = ws.clone();
-            spawn_local(async move {
-                loop {
-                    // Wait until data is written to stream
-                    let data = poll_fn(|cx| {
-                        let mut state = state.lock().unwrap();
-                        
-                        if state.send_buff.len() == 0 || state.con_state == ConnectionState::Connecting {
-                            state.send_wakers.push(cx.waker().clone());
-                            return Poll::Pending;
-                        }
-
-                        Poll::Ready(state.send_buff.drain(..).collect::<Vec<u8>>())
-                    }).await;
-
-                    {
-                        let state = state.lock().unwrap();
-
-                        if state.con_state == ConnectionState::Closing || state.con_state == ConnectionState::Closed {
-                            break;
-                        }
-                    }
-
-                    match ws.send_with_u8_array(&data) {
-                        Ok(_) => debug!("successfully sent {} bytes", data.len()),
-                        Err(err) => debug!("error sending message: {:?}", err),
-                    }
-                }
-            });
-        }
-
-        // Close loop
-        {
-            let state = Arc::clone(&state);
-            let ws = ws.clone();
-            spawn_local(async move {
-                // Wait until signalled to close
-                poll_fn(|cx| {
-                    let mut state = state.lock().unwrap();
-                    
-                    if state.con_state != ConnectionState::Closing {
-                        state.close_wakers.push(cx.waker().clone());
-                        return Poll::Pending;
-                    }
-
-                    Poll::Ready(())
-                }).await;
-
-                debug!("closing socket");
-                
-                match ws.close() {
-                    Ok(_) => debug!("successfully closed websocket"),
-                    Err(err) => debug!("error while closing websocket: {:?}", err),
-                }
-
-                let mut state = state.lock().unwrap();
-                state.con_state = ConnectionState::Closed;
-                state.wake_recv();
-                state.wake_send();
-            });
-        }
+        let url = format!(
+            "wss://{}:{}/ws",
+            config.relay_host(),
+            config.relay_ws_port()
+        );
+        let (websocket_stream, _) = client_async(url, tls_stream.compat()).await?;
 
         Ok(Self {
-            state
+            inner: websocket_stream,
+            read_buff: vec![],
+            write_buff: None,
         })
     }
 }
 
-impl AsyncRead for ServerStream {
+impl AsyncRead for WebsocketServerStream {
     fn poll_read(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        let mut state = self.state.lock().unwrap();
+        while self.read_buff.is_empty() {
+            let msg = match self.inner.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(msg))) => msg,
+                Poll::Ready(Some(Err(err))) => {
+                    error!("error while reading from websocket: {}", err);
+                    return Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)));
+                }
+                Poll::Ready(None) => return Poll::Ready(Ok(0)),
+                Poll::Pending => return Poll::Pending,
+            };
 
-        if state.recv_buff.len() == 0 {
-            if state.con_state == ConnectionState::Closing || state.con_state == ConnectionState::Closed {
-                return Poll::Ready(Ok(0));
+            if msg.is_binary() {
+                self.read_buff.extend_from_slice(msg.into_data().as_slice());
             }
-
-            state.recv_wakers.push(cx.waker().clone());
-            return Poll::Pending;
         }
 
-        let len = cmp::min(buf.len(), state.recv_buff.len());
-        &buf[..len].copy_from_slice(&state.recv_buff[..len]);
-        state.recv_buff.drain(..len);
+        let len = cmp::min(buf.len(), self.read_buff.len());
+        buf[..len].copy_from_slice(&self.read_buff[..len]);
+        self.read_buff.drain(..len);
+
         Poll::Ready(Ok(len))
     }
 }
 
-impl AsyncWrite for ServerStream {
+impl AsyncWrite for WebsocketServerStream {
     fn poll_write(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
         buf: &[u8],
-    ) -> Poll<Result<usize, io::Error>> {
-        let mut state = self.state.lock().unwrap();
+    ) -> std::task::Poll<Result<usize, io::Error>> {
+        assert!(buf.len() > 0);
 
-        if state.con_state == ConnectionState::Closing || state.con_state == ConnectionState::Closed {
-            return Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)));
+        let mut written = 0;
+        let max_size = self
+            .inner
+            .get_config()
+            .max_frame_size
+            .unwrap_or(1024 * 1024);
+
+        loop {
+            if self.write_buff.is_none() {
+                written = cmp::min(max_size, buf.len());
+                self.write_buff
+                    .replace(Message::binary(buf[..written].to_vec()));
+            }
+
+            if let Poll::Pending = self.inner.poll_ready_unpin(cx) {
+                return Poll::Pending;
+            }
+
+            let msg = self.write_buff.take().unwrap();
+            if let Err(err) = self.inner.start_send_unpin(msg) {
+                error!("error while writing to websocket: {}", err);
+                return Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)));
+            }
+
+            if written > 0 {
+                return Poll::Ready(Ok(written));
+            }
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        if self.write_buff.is_none() {
+            return Poll::Ready(Ok(()));
         }
 
-        state.send_buff.extend_from_slice(buf);
-        state.wake_send();
-
-        Poll::Ready(Ok(buf.len()))
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), io::Error>> {
-        debug!("shutting down websocket");
-        let mut state = self.state.lock().unwrap();
-
-        if state.con_state == ConnectionState::Closing || state.con_state == ConnectionState::Closed {
-            state.close_wakers.push(cx.waker().clone());
+        if let Poll::Pending = self.inner.poll_ready_unpin(cx) {
             return Poll::Pending;
         }
 
-        state.con_state = ConnectionState::Closing;
-        state.wake_close();
-        Poll::Ready(Ok(()))
-    }
-}
-
-impl Drop for ServerStream {
-    fn drop(&mut self) {
-        let mut state = self.state.lock().unwrap();
-
-        if state.con_state == ConnectionState::Closing || state.con_state == ConnectionState::Closed {
-            return;
+        let msg = self.write_buff.take().unwrap();
+        if let Err(err) = self.inner.start_send_unpin(msg) {
+            error!("error while writing to websocket: {}", err);
+            return Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)));
         }
 
-        state.con_state = ConnectionState::Closing;
-        state.wake_close();
+        if let Poll::Pending = self.inner.poll_flush_unpin(cx) {
+            return Poll::Pending;
+        }
+
+        return Poll::Ready(Ok(()));
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        self.inner.poll_close_unpin(cx).map_err(|err| {
+            error!("error while closing to websocket: {}", err);
+            io::Error::from(io::ErrorKind::BrokenPipe)
+        })
     }
 }
+
+impl super::AsyncIO for WebsocketServerStream {}

--- a/tunshell-client/src/server/websys_websocket_stream.rs
+++ b/tunshell-client/src/server/websys_websocket_stream.rs
@@ -1,0 +1,293 @@
+use crate::Config;
+use anyhow::Result;
+use std::{
+    cmp,
+    io,
+    pin::Pin,
+    task::{Context, Poll, Waker},
+    sync::{Arc, Mutex}
+};
+use tokio::io::{AsyncRead, AsyncWrite};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::{ErrorEvent, MessageEvent, WebSocket};
+use log::*;
+use futures::future::poll_fn;
+
+pub struct ServerStream {
+    state: Arc<Mutex<State>>
+}
+
+struct State {
+    con_state: ConnectionState,
+
+    recv_buff: Vec<u8>,
+    recv_wakers: Vec<Waker>,
+
+    send_buff: Vec<u8>,
+    send_wakers: Vec<Waker>,
+
+    close_wakers: Vec<Waker>,
+}
+
+impl State {
+    fn new() -> Self {
+        Self {
+            con_state: ConnectionState::Connecting,
+            recv_buff: vec![],
+            recv_wakers: vec![],
+            send_buff: vec![],
+            send_wakers: vec![],
+            close_wakers: vec![],
+        }
+    }
+
+    fn wake_recv(&mut self) {
+        for waker in self.recv_wakers.drain(..) {
+            waker.wake();
+        }
+    }
+
+    fn wake_send(&mut self) {
+        for waker in self.send_wakers.drain(..) {
+            waker.wake();
+        }
+    }
+
+    fn wake_close(&mut self) {
+        for waker in self.close_wakers.drain(..) {
+            waker.wake();
+        }
+    }
+}
+
+#[derive(PartialEq, Copy, Clone, Debug)]
+enum ConnectionState {
+    Connecting,
+    Open,
+    Closing,
+    Closed
+}
+
+impl ServerStream {
+    pub async fn connect(config: &Config) -> Result<Self> {
+        let state = State::new();
+        let state = Arc::new(Mutex::new(state));
+
+        let url = format!("wss://{}:{}/ws", config.relay_host(), config.relay_ws_port());
+        let ws = WebSocket::new(&url).unwrap();
+
+        ws.set_binary_type(web_sys::BinaryType::Arraybuffer);
+        
+        // Recv
+        {
+            let state = Arc::clone(&state);
+
+            let callback = Closure::wrap(Box::new(move |e: MessageEvent| {
+                if let Ok(abuf) = e.data().dyn_into::<js_sys::ArrayBuffer>() {
+                    let array = js_sys::Uint8Array::new(&abuf);
+                    let len = array.byte_length() as usize;
+                    debug!("message event, received arraybuffer of {} bytes", len);
+                    
+                    let mut state = state.lock().unwrap();
+
+                    state.recv_buff.extend_from_slice(&array.to_vec()[..]);
+                    state.wake_recv();
+                } else if let Ok(blob) = e.data().dyn_into::<web_sys::Blob>() {
+                    warn!("message event, received blob: {:?}", blob);
+                } else if let Ok(txt) = e.data().dyn_into::<js_sys::JsString>() {
+                    warn!("message event, received Text: {:?}", txt);
+                } else {
+                    warn!("message event, received Unknown: {:?}", e.data());
+                }
+            }) as Box<dyn FnMut(MessageEvent)>);
+
+            ws.set_onmessage(Some(callback.as_ref().unchecked_ref()));
+            callback.forget();
+        }
+
+        // Error
+        {
+            let callback = Closure::wrap(Box::new(move |e: ErrorEvent| {
+                error!("error event: {:?}", e);
+            }) as Box<dyn FnMut(ErrorEvent)>);
+            ws.set_onerror(Some(callback.as_ref().unchecked_ref()));
+            callback.forget();
+        }
+
+        // Closed
+        {
+            let state = Arc::clone(&state);
+            let callback = Closure::wrap(Box::new(move |_e: ErrorEvent| {
+                let mut state = state.lock().unwrap();
+                state.con_state = ConnectionState::Closed;
+                state.wake_close();
+                state.wake_recv();
+                state.wake_send();
+                debug!("socket closed");
+            }) as Box<dyn FnMut(ErrorEvent)>);
+            ws.set_onclose(Some(callback.as_ref().unchecked_ref()));
+            callback.forget();
+        }
+
+        // Open 
+        {
+            let state = Arc::clone(&state);
+            let callback = Closure::wrap(Box::new(move |_| {
+                let mut state = state.lock().unwrap();
+                state.con_state = ConnectionState::Open;
+                state.wake_send();
+                debug!("socket opened");
+            }) as Box<dyn FnMut(JsValue)>);
+            ws.set_onopen(Some(callback.as_ref().unchecked_ref()));
+            callback.forget();
+        }
+
+        // Write loop
+        {
+            let state = Arc::clone(&state);
+            let ws = ws.clone();
+            spawn_local(async move {
+                loop {
+                    // Wait until data is written to stream
+                    let data = poll_fn(|cx| {
+                        let mut state = state.lock().unwrap();
+                        
+                        if state.send_buff.len() == 0 || state.con_state == ConnectionState::Connecting {
+                            state.send_wakers.push(cx.waker().clone());
+                            return Poll::Pending;
+                        }
+
+                        Poll::Ready(state.send_buff.drain(..).collect::<Vec<u8>>())
+                    }).await;
+
+                    {
+                        let state = state.lock().unwrap();
+
+                        if state.con_state == ConnectionState::Closing || state.con_state == ConnectionState::Closed {
+                            break;
+                        }
+                    }
+
+                    match ws.send_with_u8_array(&data) {
+                        Ok(_) => debug!("successfully sent {} bytes", data.len()),
+                        Err(err) => debug!("error sending message: {:?}", err),
+                    }
+                }
+            });
+        }
+
+        // Close loop
+        {
+            let state = Arc::clone(&state);
+            let ws = ws.clone();
+            spawn_local(async move {
+                // Wait until signalled to close
+                poll_fn(|cx| {
+                    let mut state = state.lock().unwrap();
+                    
+                    if state.con_state != ConnectionState::Closing {
+                        state.close_wakers.push(cx.waker().clone());
+                        return Poll::Pending;
+                    }
+
+                    Poll::Ready(())
+                }).await;
+
+                debug!("closing socket");
+                
+                match ws.close() {
+                    Ok(_) => debug!("successfully closed websocket"),
+                    Err(err) => debug!("error while closing websocket: {:?}", err),
+                }
+
+                let mut state = state.lock().unwrap();
+                state.con_state = ConnectionState::Closed;
+                state.wake_recv();
+                state.wake_send();
+            });
+        }
+
+        Ok(Self {
+            state
+        })
+    }
+}
+
+impl AsyncRead for ServerStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let mut state = self.state.lock().unwrap();
+
+        if state.recv_buff.len() == 0 {
+            if state.con_state == ConnectionState::Closing || state.con_state == ConnectionState::Closed {
+                return Poll::Ready(Ok(0));
+            }
+
+            state.recv_wakers.push(cx.waker().clone());
+            return Poll::Pending;
+        }
+
+        let len = cmp::min(buf.len(), state.recv_buff.len());
+        &buf[..len].copy_from_slice(&state.recv_buff[..len]);
+        state.recv_buff.drain(..len);
+        Poll::Ready(Ok(len))
+    }
+}
+
+impl AsyncWrite for ServerStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let mut state = self.state.lock().unwrap();
+
+        if state.con_state == ConnectionState::Closing || state.con_state == ConnectionState::Closed {
+            return Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)));
+        }
+
+        state.send_buff.extend_from_slice(buf);
+        state.wake_send();
+
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        debug!("shutting down websocket");
+        let mut state = self.state.lock().unwrap();
+
+        if state.con_state == ConnectionState::Closing || state.con_state == ConnectionState::Closed {
+            state.close_wakers.push(cx.waker().clone());
+            return Poll::Pending;
+        }
+
+        state.con_state = ConnectionState::Closing;
+        state.wake_close();
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl Drop for ServerStream {
+    fn drop(&mut self) {
+        let mut state = self.state.lock().unwrap();
+
+        if state.con_state == ConnectionState::Closing || state.con_state == ConnectionState::Closed {
+            return;
+        }
+
+        state.con_state = ConnectionState::Closing;
+        state.wake_close();
+    }
+}

--- a/tunshell-client/src/wasm.rs
+++ b/tunshell-client/src/wasm.rs
@@ -90,6 +90,7 @@ pub async fn tunshell_init_client(config: BrowserConfig) {
         ClientMode::Local,
         &config.client_key,
         &config.relay_server,
+        5000,
         443,
         &config.encryption_key,
         false


### PR DESCRIPTION
In some environments most outbound ports are blocked which can prevent the client connecting to the relay server on default port 5000. 
If the initial raw TLS connection fails, fallback to initiating a websocket based connection on port 443 (like the wasm in-browser client).