### PR TITLE
feat: add build target for Apple M1 chip

### DIFF
--- a/.github/workflows/deploy-client-binaries.yml
+++ b/.github/workflows/deploy-client-binaries.yml
@@ -46,6 +46,8 @@ jobs:
             tests: true
           - platform: macos-latest
             target: x86_64-apple-ios
+          - platform: macos-latest
+            target: aarch64-apple-darwin
           # Windows
           - platform: windows-latest
             target: x86_64-pc-windows-msvc

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -20,6 +20,7 @@
       },
       darwin: {
         x64: "x86_64-apple-darwin",
+        arm64: "aarch64-apple-darwin",
       },
       win32: {
         x64: "x86_64-pc-windows-msvc.exe",

--- a/scripts/init.php
+++ b/scripts/init.php
@@ -12,6 +12,7 @@ return function (array $args) {
     ],
     'Darwin' => [
       'x86_64' => 'x86_64-apple-darwin',
+      'arm64' => 'aarch64-apple-darwin',
     ],
     'WindowsNT' => [
       'x86_64' => 'x86_64-pc-windows-msvc.exe',

--- a/scripts/init.py
+++ b/scripts/init.py
@@ -16,6 +16,7 @@ def get_target():
       },
       'Darwin': {
         'x86_64': 'x86_64-apple-darwin',
+        'arm64': 'aarch64-apple-darwin',
       },
       'Windows': {
         'x86_64': 'x86_64-pc-windows-msvc',

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -41,6 +41,9 @@ main() {
     Darwin:x86_64*)    
         TARGET="x86_64-apple-darwin"
         ;;
+    Darwin:arm64*)    
+        TARGET="aarch64-apple-darwin"
+        ;;
     WindowsNT:x86_64*|MINGW64_NT*:x86_64*)
         TARGET="x86_64-pc-windows-msvc.exe"
         ;;

--- a/scripts/java/init.java
+++ b/scripts/java/init.java
@@ -104,6 +104,7 @@ public class init {
     targets.put(new OsArch(Os.LINUX, Arch.ARM), "armv7-unknown-linux-musleabihf");
     targets.put(new OsArch(Os.LINUX, Arch.ARM64), "aarch64-unknown-linux-musl");
     targets.put(new OsArch(Os.OSX, Arch.X86_64), "x86_64-apple-darwin");
+    targets.put(new OsArch(Os.OSX, Arch.ARM64), "aarch64-apple-darwin");
     targets.put(new OsArch(Os.WINDOWS, Arch.X86_64), "x86_64-pc-windows-msvc.exe");
     targets.put(new OsArch(Os.WINDOWS, Arch.I686), "i686-pc-windows-msvc.exe");
     SUPPORTED_TARGETS = Collections.unmodifiableMap(targets);

--- a/scripts/netcore/init.cs
+++ b/scripts/netcore/init.cs
@@ -24,6 +24,7 @@ namespace Tunshell
                 OSPlatform.OSX,
                 new Dictionary<Architecture, string>{
                     {Architecture.X64, "x86_64-apple-darwin"},
+                    {Architecture.Arm64, "aarch64-apple-darwin"},
                 }
             },
             {


### PR DESCRIPTION
Tunshell client doesn't have support for a new Apple M1 chip, this PR should enable it
`aarch64-apple-darwin` target is listed [here](https://doc.rust-lang.org/rustc/platform-support.html#tier-2-with-host-tools) 