### PR TITLE
Compile on android

### DIFF
--- a/tunshell-client/Cargo.toml
+++ b/tunshell-client/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0.114"
 serde_json = "1.0.55"
 cfg-if = "0.1.10"
 
-[target.'cfg(all(not(target_os = "ios"), not(target_os = "android"), not(target_arch = "wasm32")))'.dependencies]
+[target.'cfg(all(not(target_os = "ios"), not(target_arch = "wasm32")))'.dependencies]
 portable-pty = "0.3.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/tunshell-client/src/shell/server/mod.rs
+++ b/tunshell-client/src/shell/server/mod.rs
@@ -17,7 +17,7 @@ mod shell;
 use shell::*;
 
 cfg_if::cfg_if! {
-    if #[cfg(all(not(target_os = "ios"), not(target_os = "android")))] {
+    if #[cfg(all(not(target_os = "ios")))] {
         mod pty;
         use pty::*;
     }
@@ -107,7 +107,7 @@ impl ShellServer {
             _ = time::delay_for(Duration::from_millis(3000)) => return Err(Error::msg("timed out while waiting for shell request"))
         };
 
-        #[cfg(all(not(target_os = "ios"), not(target_os = "android")))]
+        #[cfg(all(not(target_os = "ios")))]
         {
             debug!("initialising pty shell");
             let pty_shell = PtyShell::new(request.term.as_ref(), None, request.size.clone());


### PR DESCRIPTION
Allow compilation on android so that the users can override abandoned `serial` crate.